### PR TITLE
Change scope of watches to namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,3 +223,17 @@ All notable changes to this project will be documented in this file.
 | [search-indexer](https://github.com/stolostron/search-indexer)         | quay.io/stolostron/search-indexer:2.7.0-SNAPSHOT-2022-10-04-17-27-14   |
 | [search-v2-api](https://github.com/stolostron/search-v2-api)           | quay.io/stolostron/search-v2-api:2.7.0-SNAPSHOT-2022-10-04-17-27-14       |
 | [search-v2-operator](https://github.com/stolostron/search-v2-operator) | quay.io/stolostron/search-v2-operator:2.7.0-SNAPSHOT-2022-10-04-17-27-14  |
+
+### Date of Change: 10-13-2022
+
+---
+
+#### Updated Build Version: Thu Oct 13 00:28:18 EDT 2022
+
+| Image Name                                                             | Image Component  |
+|------------------------------------------------------------------------|------------------|
+| [postgresql-13](https://catalog.redhat.com/software/containers/rhel8/postgresql-13/5ffdbdef73a65398111b8362) | registry.redhat.io/rhel8/postgresql-13@sha256:d8ec037e60575b86320fdc162117600240ce53038fb8b9b7296ce525d2b8e605  |
+| [search-collector](https://github.com/stolostron/search-collector)     | quay.io/stolostron/search-collector:2.7.0-4f4c8f5770b14b31d16384abb1f5601e0018eb9f |
+| [search-indexer](https://github.com/stolostron/search-indexer)         | quay.io/stolostron/search-indexer:2.7.0-28fa5ea9002e92a95ae748863fe23ac94782732e   |
+| [search-v2-api](https://github.com/stolostron/search-v2-api)           | quay.io/stolostron/search-v2-api:2.7.0-fb6729cbd08de79fc0766ba47d82565ebbfd6f2a       |
+| [search-v2-operator](https://github.com/stolostron/search-v2-operator) | quay.io/stolostron/search-v2-operator:2.7.0-9de8a07f2ba1d6cdc2aa89b85948b6c6903c8cf5  |

--- a/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/search-v2-operator.clusterserviceversion.yaml
@@ -76,23 +76,6 @@ spec:
               verbs:
                 - create
             - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - replicasets
-              verbs:
-                - '*'
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - secrets
-                - serviceaccounts
-                - services
-                - persistentvolumeclaims
-              verbs:
-                - '*'
-            - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
                 - clusterrolebindings
@@ -217,7 +200,7 @@ spec:
                       - --leader-elect
                     command:
                       - /manager
-                    image: quay.io/stolostron/search-v2-operator:2.7.0-SNAPSHOT-2022-10-04-17-27-14
+                    image: quay.io/stolostron/search-v2-operator:2.7.0-9de8a07f2ba1d6cdc2aa89b85948b6c6903c8cf5
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -226,14 +209,18 @@ spec:
                       periodSeconds: 20
                     name: manager
                     env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: POSTGRES_IMAGE
                         value: registry.redhat.io/rhel8/postgresql-13@sha256:d8ec037e60575b86320fdc162117600240ce53038fb8b9b7296ce525d2b8e605
                       - name: INDEXER_IMAGE
-                        value: quay.io/stolostron/search-indexer:2.7.0-SNAPSHOT-2022-10-04-17-27-14
+                        value: quay.io/stolostron/search-indexer:2.7.0-28fa5ea9002e92a95ae748863fe23ac94782732e
                       - name: COLLECTOR_IMAGE
-                        value: quay.io/stolostron/search-collector:2.7.0-SNAPSHOT-2022-10-04-17-27-14
+                        value: quay.io/stolostron/search-collector:2.7.0-4f4c8f5770b14b31d16384abb1f5601e0018eb9f
                       - name: API_IMAGE
-                        value: quay.io/stolostron/search-v2-api:2.7.0-SNAPSHOT-2022-10-04-17-27-14
+                        value: quay.io/stolostron/search-v2-api:2.7.0-fb6729cbd08de79fc0766ba47d82565ebbfd6f2a
                     readinessProbe:
                       httpGet:
                         path: /readyz
@@ -259,17 +246,22 @@ spec:
       permissions:
         - rules:
             - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
                 - ""
               resources:
                 - configmaps
+                - secrets
+                - serviceaccounts
+                - services
+                - persistentvolumeclaims
               verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
+                - '*'
             - apiGroups:
                 - coordination.k8s.io
               resources:


### PR DESCRIPTION
Signed-off-by: Xavier Dharmaiyan <xavier@redhat.com>

**Related Issue:**  stolostron/backlog#25847
**Search Operator PR:** https://github.com/stolostron/search-v2-operator/pull/81

### Description of changes
- Reduces the scope of resources watched by the operator to only the namespace where it's deployed.

